### PR TITLE
FIX: Update mobile layout based on latest update

### DIFF
--- a/mobile/head_tag.html
+++ b/mobile/head_tag.html
@@ -1,5 +1,5 @@
 <script type='text/x-handlebars' data-template-name='mobile/list/topic-list-item.raw'>
-    <td>
+    <td class="topic-list-data">
       {{~#unless expandPinned}}
       <div class='pull-left'>
         <a href="{{topic.creator.path}}" data-user-card="{{topic.creator.username}}">{{avatar topic.creator imageSize="large"}}</a>

--- a/mobile/head_tag.html
+++ b/mobile/head_tag.html
@@ -2,7 +2,7 @@
     <td>
       {{~#unless expandPinned}}
       <div class='pull-left'>
-        <a href="/users/{{topic.creator.username}}">{{avatar topic.creator imageSize="large"}}</a>
+        <a href="{{topic.creator.path}}" data-user-card="{{topic.creator.username}}">{{avatar topic.creator imageSize="large"}}</a>
       </div>
       <div class='right'>
       {{else}}


### PR DESCRIPTION
Fix mobile version based on this update:  https://meta.discourse.org/t/modernizing-our-topic-list-html-preparing-themes-components-and-plugins/209654

> We’ve recently added 5 .topic-list-header , .topic-list-body and .topic-list-data classes to begin the transition.

