### PR TITLE
FEATURE: Add setting to show author before topic column

### DIFF
--- a/desktop/head_tag.html
+++ b/desktop/head_tag.html
@@ -8,11 +8,7 @@
   {{#unless (theme-setting 'show_author_username')}}
     <td class='author topic-list-data'>
       <a href="{{topic.creator.path}}" data-user-card="{{topic.creator.username}}">
-        {{#if (theme-setting 'show_author_username')}}
-          {{topic.creator.username}}
-          {{else}}
-          {{avatar topic.creator imageSize="45"}}
-        {{/if}} 
+        {{avatar topic.creator imageSize="45"}}
       </a>
     </td>
   {{/unless}}
@@ -65,11 +61,7 @@
   {{#if (theme-setting 'show_author_username')}}
     <td class='author topic-list-data'>
       <a href="{{topic.creator.path}}" data-user-card="{{topic.creator.username}}">
-        {{#if (theme-setting 'show_author_username')}}
-          {{topic.creator.username}}
-          {{else}}
-          {{avatar topic.creator imageSize="45"}}
-        {{/if}} 
+        {{topic.creator.username}}
       </a>
     </td>
   {{/if}}

--- a/desktop/head_tag.html
+++ b/desktop/head_tag.html
@@ -4,6 +4,20 @@
   {{raw "list/posters-column" posters=topic.participants}}
 {{/if}}
 
+{{#if (theme-setting 'show_author_before_topic')}}
+  {{#unless (theme-setting 'show_author_username')}}
+    <td class='author topic-list-data'>
+      <a href="{{topic.creator.path}}" data-user-card="{{topic.creator.username}}">
+        {{#if (theme-setting 'show_author_username')}}
+          {{topic.creator.username}}
+          {{else}}
+          {{avatar topic.creator imageSize="45"}}
+        {{/if}} 
+      </a>
+    </td>
+  {{/unless}}
+{{/if}}
+
 {{#if bulkSelectEnabled}}
   <td class="bulk-select topic-list-data">
     <input type="checkbox" class="bulk-select">
@@ -20,7 +34,7 @@
     {{~/if}}
     {{~raw-plugin-outlet name="topic-list-after-title"}}
     {{~#if showTopicPostBadges}}
-    {{~raw "topic-post-badges" unread=topic.unread newPosts=topic.displayNewPosts unseen=topic.unseen url=topic.lastUnreadUrl newDotText=newDotText}}
+    {{~raw "topic-post-badges" unreadPosts=topic.unread_posts unseen=topic.unseen url=topic.lastUnreadUrl newDotText=newDotText}}
     {{~/if}}
   </span>
   <div class="link-bottom-line">
@@ -37,15 +51,29 @@
   {{/if}}
 </td>
 
-<td class='author topic-list-data'>
-  <a href="{{topic.creator.path}}" data-user-card="{{topic.creator.username}}">
-    {{#if (theme-setting 'show_author_username')}}
-      {{topic.creator.username}}
-      {{else}}
-      {{avatar topic.creator imageSize="45"}}
-    {{/if}} 
-  </a>
-</td>
+{{#unless (theme-setting 'show_author_before_topic')}}  
+  <td class='author topic-list-data'>
+    <a href="{{topic.creator.path}}" data-user-card="{{topic.creator.username}}">
+      {{#if (theme-setting 'show_author_username')}}
+        {{topic.creator.username}}
+        {{else}}
+        {{avatar topic.creator imageSize="45"}}
+      {{/if}} 
+    </a>
+  </td>
+  {{else}}
+  {{#if (theme-setting 'show_author_username')}}
+    <td class='author topic-list-data'>
+      <a href="{{topic.creator.path}}" data-user-card="{{topic.creator.username}}">
+        {{#if (theme-setting 'show_author_username')}}
+          {{topic.creator.username}}
+          {{else}}
+          {{avatar topic.creator imageSize="45"}}
+        {{/if}} 
+      </a>
+    </td>
+  {{/if}}
+{{/unless}}
 
 {{raw "list/posts-count-column" topic=topic}}
 
@@ -84,11 +112,28 @@
     {{/if}}
   </th>
 {{/if}}
+
+{{#if (theme-setting 'show_author_before_topic')}}
+  {{#unless (theme-setting 'show_author_username')}}
+    {{#if showPosters}}
+      {{raw "topic-list-header-column" order='posters' forceName=(theme-i18n "author") }}
+    {{/if}}
+  {{/unless}}
+{{/if}}
+
 {{raw "topic-list-header-column" order='default' name=listTitle bulkSelectEnabled=bulkSelectEnabled showBulkToggle=toggleInTitle canBulkSelect=canBulkSelect}}
 
-{{#if showPosters}}
-  {{raw "topic-list-header-column" order='posters' forceName=(theme-i18n "author") }}
-{{/if}}
+{{#unless (theme-setting 'show_author_before_topic')}}
+  {{#if showPosters}}
+    {{raw "topic-list-header-column" order='posters' forceName=(theme-i18n "author") }}
+  {{/if}}
+  {{else}}
+  {{#if (theme-setting 'show_author_username')}}
+    {{#if showPosters}}
+      {{raw "topic-list-header-column" order='posters' forceName=(theme-i18n "author") }}
+    {{/if}}
+  {{/if}}
+{{/unless}}
 
 {{raw "topic-list-header-column" sortable=sortable number='true' order='posts' name='replies'}}
 {{#if showLikes}}

--- a/mobile/head_tag.html
+++ b/mobile/head_tag.html
@@ -2,13 +2,11 @@
   <td class="topic-list-data">
     {{~raw-plugin-outlet name="topic-list-before-columns"}}
     
-    {{#if (theme-setting 'show_author_username')}}
-      <div class='hidden-avatar'></div>
-      {{else}}
+    {{#unless (theme-setting 'show_author_username')}}
       <div class='pull-left'>
         <a href="{{topic.creator.path}}" data-user-card="{{topic.creator.username}}">{{avatar topic.creator imageSize="large"}}</a>
       </div>
-    {{/if}}
+    {{/unless}}
 
     <div class='right'>
       <div class='main-link'>
@@ -41,7 +39,7 @@
         {{discourse-tags topic mode="list"}}
  
         {{#if (theme-setting 'show_author_username')}}
-          <div class="pull-right with-username">
+          <div class="pull-right">
             <a href="{{topic.creator.path}}" data-user-card="{{topic.creator.username}}">
               {{topic.creator.username}}
             </a>

--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -1,26 +1,24 @@
-.topic-list .topic-list-data {
-  .hidden-avatar {
-    + .right {
+ @if $show_author_username == "true" {
+  .topic-list .topic-list-data {
+    .right {
       margin-left: 0;
     }
-  }
-  .main-link a.title {
-    padding: 0.5em 0;
-    + .pull-right.with-username {
-      margin: 0;
+    .main-link a.title {
+      padding: 0.5em 0;
+      + .pull-right {
+        margin: 0;
+      }
     }
-  }
-  .pull-right {
-    &.with-username {
-      display: flex;
-      justify-content: space-between;
-      width: 100%;
-    }
-  }
-  .topic-item-stats {
-    .category,
-    .discourse-tags {
-      margin-bottom: 0.5em;
+    .topic-item-stats {
+      .category,
+      .discourse-tags {
+        margin-bottom: 0.5em;
+      }
+      .pull-right {
+        display: flex;
+        justify-content: space-between;
+        width: 100%;
+      }
     }
   }
 }

--- a/settings.yml
+++ b/settings.yml
@@ -2,9 +2,9 @@ show_author_username:
   type: bool
   default: false
   description:
-    en: "Display author username after topic column instead profile avatar"
+    en: "Display author username instead profile avatar"
 show_author_before_topic:
   type: bool
   default: false
   description:
-    en: "Display author avatar before topic column"
+    en: "Display author profile avatar before topic column"

--- a/settings.yml
+++ b/settings.yml
@@ -2,9 +2,9 @@ show_author_username:
   type: bool
   default: false
   description:
-    en: "Show author username instead profile avatar"
+    en: "Display author username after topic column instead profile avatar"
 show_author_before_topic:
   type: bool
   default: false
   description:
-    en: "Show author avatar before topic column on desktop"
+    en: "Display author avatar before topic column"

--- a/settings.yml
+++ b/settings.yml
@@ -3,3 +3,8 @@ show_author_username:
   default: false
   description:
     en: "Show author username instead profile avatar"
+show_author_before_topic:
+  type: bool
+  default: false
+  description:
+    en: "Show author avatar before topic column on desktop"


### PR DESCRIPTION
Author column now appear after topic column by default. This PR add a theme setting to move author column before topic column if it display author avatar. It means if the **show author username** setting is on then the author column appear after topic even if the **show author before topic** setting is on too.

![Screenshot 2022-02-14 at 21 02 41](https://user-images.githubusercontent.com/71207900/153937699-80d81431-ecb6-4e4e-95d0-d19722f22a5f.png)


**Default**
![Screenshot 2022-02-14 at 13 05 06](https://user-images.githubusercontent.com/71207900/153861224-3e532dd2-388d-4125-be33-b5ec601daafa.png)

**Before topic column**
![Screenshot 2022-02-14 at 13 06 03](https://user-images.githubusercontent.com/71207900/153861364-51a9534e-79e5-46fd-8a2a-e875afed4788.png)

**With username**
![Screenshot 2022-02-14 at 13 06 44](https://user-images.githubusercontent.com/71207900/153861460-3ceab576-b42f-446e-ae1e-38a4ca9cc438.png)

---

This PR fix a deprecated `displayNewPosts` warning too.

Thanks! 🙂 